### PR TITLE
Fixing the UseCors issue

### DIFF
--- a/UserInterface/TanzuTacos.WebApi/Controllers/SpecialsController.cs
+++ b/UserInterface/TanzuTacos.WebApi/Controllers/SpecialsController.cs
@@ -10,7 +10,6 @@ namespace TanzuTacos.WebApi.Controllers
 	[ApiController]
 	public class SpecialsController : Controller
 	{
-		[DisableCors]
 		[HttpGet]
 		public async Task<ActionResult<List<TacoSpecial>>> GetSpecialsAsync()
 		{

--- a/UserInterface/TanzuTacos.WebApi/Startup.cs
+++ b/UserInterface/TanzuTacos.WebApi/Startup.cs
@@ -61,9 +61,9 @@ namespace TanzuTacos.WebApi
 
 			app.UseHttpsRedirection();
 
-			app.UseRouting();
-
 			app.UseCors();
+
+			app.UseRouting();
 
 			app.UseAuthorization();
 

--- a/UserInterface/TanzuTacos.WebApi/Startup.cs
+++ b/UserInterface/TanzuTacos.WebApi/Startup.cs
@@ -61,9 +61,9 @@ namespace TanzuTacos.WebApi
 
 			app.UseHttpsRedirection();
 
-			app.UseCors();
-
 			app.UseRouting();
+
+			app.UseCors();
 
 			app.UseAuthorization();
 


### PR DESCRIPTION
Per the following docs, UseCors must be called before UseRouting and is very finicky about call order.

https://docs.microsoft.com/en-us/aspnet/core/security/cors?view=aspnetcore-5.0#enable-cors

`UseCors must be called in the correct order. For more information, see Middleware order. For example, UseCors must be called before UseResponseCaching when using UseResponseCaching.`